### PR TITLE
move start from handler to task

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,2 @@
 ---
 # handlers file for revenni.falco
-
-- name: falco | restart
-  systemd:
-    name: falco
-    state: restarted
-    daemon-reload: yes
-    enabled: yes

--- a/tasks/configure_falco.yml
+++ b/tasks/configure_falco.yml
@@ -8,7 +8,6 @@
     owner: root
     group: root
     mode: '0640'
-  notify: falco | restart
 
 - name: falco | configure local rules
   template:
@@ -17,4 +16,11 @@
     owner: root
     group: root
     mode: '0640'
-  notify: falco | restart
+
+- name: falco | start
+  systemd:
+    name: falco
+    state: started
+    daemon-reload: yes
+    enabled: yes
+


### PR DESCRIPTION
Move falco systemd from handler to task.  Avoids partial playbook runs from skipping systemd start/enable.

Closes #4 